### PR TITLE
Refactored tests after upgrade to React 0.14, refactor Avatar

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
     "react/jsx-no-duplicate-props": 1,
     "react/jsx-no-undef": 1,
     "react/jsx-sort-prop-types": 1,
+    "react/jsx-uses-react": 1,
     "react/no-did-mount-set-state": [ 1, "allow-in-func" ],
     "react/no-did-update-set-state": 1,
     "react/react-in-jsx-scope": 1,

--- a/client/js/components/Avatar/Avatar.jsx
+++ b/client/js/components/Avatar/Avatar.jsx
@@ -1,22 +1,15 @@
 import React from "react";
 import "./Avatar.less";
 
-export default React.createClass( {
-	propTypes: {
-		className: React.PropTypes.string,
-		owner: React.PropTypes.string,
-		size: React.PropTypes.number
-	},
-	getDefaultProps() {
-		return {
-			owner: "anonymous",
-			size: 16,
-			className: "avatar"
-		};
-	},
-	render() {
-		return (
-			<img className={ this.props.className } src={ `https://avatars.githubusercontent.com/${ this.props.owner }?s=${ this.props.size }` } />
-		);
-	}
-} );
+const Avatar = ( { className = "avatar", owner = "anonymous", size = 16 } ) => {
+	const src = `https://avatars.githubusercontent.com/${ owner }?s=${ size }`;
+	return <img className={ className } src={ src } />;
+};
+
+Avatar.propTypes = {
+	className: React.PropTypes.string,
+	owner: React.PropTypes.string,
+	size: React.PropTypes.number
+};
+
+export default Avatar;

--- a/client/spec/components/App.spec.jsx
+++ b/client/spec/components/App.spec.jsx
@@ -1,7 +1,7 @@
 import appFactory from "inject!App";
 
 describe( "App Component", () => {
-	let component, initializePageStub, dependencies, windowStub;
+	let component, initializePageStub, dependencies, windowStub, container, App;
 
 	beforeEach( () => {
 		initializePageStub = sinon.stub();
@@ -29,14 +29,15 @@ describe( "App Component", () => {
 			}
 		};
 
-		const App = appFactory( dependencies );
+		App = appFactory( dependencies );
 
 		const props = {
 			params: { id: "123" },
 			query: { boardId: "456" }
 		};
 
-		component = ReactUtils.renderIntoDocument( <App { ...props } /> );
+		container = document.createElement( "div" );
+		component = ReactDOM.render( <App { ...props } />, container );
 	} );
 
 	afterEach( () => {
@@ -59,9 +60,7 @@ describe( "App Component", () => {
 	} );
 
 	it( "should update the document title to reflect the current project", () => {
-		component.setProps( {
-			params: { name: "core-blu" }
-		} );
+		ReactDOM.render( <App params={ { name: "core-blu" } } />, container );
 		windowStub.document.title.should.equal( "core-blu - Nonstop Index" );
 	} );
 

--- a/client/spec/components/Avatar.spec.jsx
+++ b/client/spec/components/Avatar.spec.jsx
@@ -1,27 +1,24 @@
 import Avatar from "Avatar";
 
 describe( "Avatar", () => {
-	let component;
+	let component, container;
+
+	beforeEach( () => {
+		container = document.createElement( "div" );
+	} );
 
 	function render( props ) {
-		component = ReactUtils.renderIntoDocument( <Avatar {...props} /> );
+		ReactDOM.render( <Avatar {...props} />, container );
+		component = container.children[ 0 ];
 	}
-
-	afterEach( () => {
-		if ( component ) {
-			ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( component ).parentNode );
-			component = null;
-		}
-	} );
 
 	describe( "when handling props", () => {
 		it( "should have default props", () => {
 			render();
-			component.props.should.eql( {
-				owner: "anonymous",
-				size: 16,
-				className: "avatar"
-			} );
+
+			component.nodeName.toLowerCase().should.equal( "img" );
+			component.src.should.equal( "https://avatars.githubusercontent.com/anonymous?s=16" );
+			component.className.should.equal( "avatar" );
 		} );
 	} );
 
@@ -33,11 +30,9 @@ describe( "Avatar", () => {
 				className: "new-class"
 			} );
 
-			const node = ReactDOM.findDOMNode( component );
-
-			node.nodeName.toLowerCase().should.equal( "img" );
-			node.src.should.equal( "https://avatars.githubusercontent.com/LeanKit-Labs?s=20" );
-			node.className.should.equal( "new-class" );
+			component.nodeName.toLowerCase().should.equal( "img" );
+			component.src.should.equal( "https://avatars.githubusercontent.com/LeanKit-Labs?s=20" );
+			component.className.should.equal( "new-class" );
 		} );
 	} );
 } );

--- a/client/spec/components/Avatar.spec.jsx
+++ b/client/spec/components/Avatar.spec.jsx
@@ -1,7 +1,7 @@
 import Avatar from "Avatar";
 
 describe( "Avatar", () => {
-	let component, container;
+	let img, container;
 
 	beforeEach( () => {
 		container = document.createElement( "div" );
@@ -9,16 +9,16 @@ describe( "Avatar", () => {
 
 	function render( props ) {
 		ReactDOM.render( <Avatar {...props} />, container );
-		component = container.children[ 0 ];
+		img = container.children[ 0 ];
 	}
 
 	describe( "when handling props", () => {
 		it( "should have default props", () => {
 			render();
 
-			component.nodeName.toLowerCase().should.equal( "img" );
-			component.src.should.equal( "https://avatars.githubusercontent.com/anonymous?s=16" );
-			component.className.should.equal( "avatar" );
+			img.nodeName.toLowerCase().should.equal( "img" );
+			img.src.should.equal( "https://avatars.githubusercontent.com/anonymous?s=16" );
+			img.className.should.equal( "avatar" );
 		} );
 	} );
 
@@ -30,9 +30,9 @@ describe( "Avatar", () => {
 				className: "new-class"
 			} );
 
-			component.nodeName.toLowerCase().should.equal( "img" );
-			component.src.should.equal( "https://avatars.githubusercontent.com/LeanKit-Labs?s=20" );
-			component.className.should.equal( "new-class" );
+			img.nodeName.toLowerCase().should.equal( "img" );
+			img.src.should.equal( "https://avatars.githubusercontent.com/LeanKit-Labs?s=20" );
+			img.className.should.equal( "new-class" );
 		} );
 	} );
 } );

--- a/client/spec/components/Avatar.spec.jsx
+++ b/client/spec/components/Avatar.spec.jsx
@@ -1,25 +1,22 @@
-import avatarFactory from "inject!Avatar";
-import ReactDOM from "react-dom";
+import Avatar from "Avatar";
 
 describe( "Avatar", () => {
-	let component, dependencies;
+	let component;
 
-	beforeEach( () => {
-		dependencies = {};
-
-		const Avatar = avatarFactory( dependencies );
-
-		component = ReactUtils.renderIntoDocument( <Avatar /> );
-	} );
+	function render( props ) {
+		component = ReactUtils.renderIntoDocument( <Avatar {...props} /> );
+	}
 
 	afterEach( () => {
 		if ( component ) {
 			ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( component ).parentNode );
+			component = null;
 		}
 	} );
 
 	describe( "when handling props", () => {
 		it( "should have default props", () => {
+			render();
 			component.props.should.eql( {
 				owner: "anonymous",
 				size: 16,
@@ -30,13 +27,13 @@ describe( "Avatar", () => {
 
 	describe( "when rendering", () => {
 		it( "should render properly", () => {
-			const node = component.getDOMNode();
-
-			component.setProps( {
+			render( {
 				owner: "LeanKit-Labs",
 				size: 20,
 				className: "new-class"
 			} );
+
+			const node = ReactDOM.findDOMNode( component );
 
 			node.nodeName.toLowerCase().should.equal( "img" );
 			node.src.should.equal( "https://avatars.githubusercontent.com/LeanKit-Labs?s=20" );

--- a/client/spec/components/Logo.spec.jsx
+++ b/client/spec/components/Logo.spec.jsx
@@ -1,24 +1,22 @@
-import logoFactory from "inject!Logo";
+import Logo from "Logo";
 
 describe( "Logo", () => {
-	let component, dependencies;
+	let component;
 
-	beforeEach( () => {
-		dependencies = {};
-
-		const Logo = logoFactory( dependencies );
-
-		component = ReactUtils.renderIntoDocument( <Logo /> );
-	} );
+	function render( props = {} ) {
+		component = ReactUtils.renderIntoDocument( <Logo {...props} /> );
+	}
 
 	afterEach( () => {
 		if ( component ) {
 			ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( component ).parentNode );
+			component = null;
 		}
 	} );
 
 	describe( "when handling props", () => {
 		it( "should have default props", () => {
+			render();
 			component.props.should.eql( {
 				className: ""
 			} );
@@ -27,18 +25,20 @@ describe( "Logo", () => {
 
 	describe( "when rendering", () => {
 		it( "should render properly", () => {
-			component.getDOMNode().nodeName.toLowerCase().should.equal( "svg" );
+			render();
+			ReactDOM.findDOMNode( component ).nodeName.toLowerCase().should.equal( "svg" );
 		} );
 
 		it( "should apply the proper default class", () => {
-			let className = component.getDOMNode().className;
+			render();
+			let className = ReactDOM.findDOMNode( component ).className;
 			className = className.baseVal || className;
 			className.should.equal( "ns-logo" );
 		} );
 
 		it( "should apply the class from props", () => {
-			component.setProps( { className: "my-logo" } );
-			let className = component.getDOMNode().className;
+			render( { className: "my-logo" } );
+			let className = ReactDOM.findDOMNode( component ).className;
 			className = className.baseVal || className;
 			className.should.equal( "ns-logo my-logo" );
 		} );

--- a/client/spec/components/ProjectDetail.spec.jsx
+++ b/client/spec/components/ProjectDetail.spec.jsx
@@ -1,7 +1,7 @@
 import projectDetailFactory from "inject!ProjectDetail";
 
 describe( "ProjectDetail Component", () => {
-	let component, dependencies, actions, ProjectDetail;
+	let component, dependencies, actions, ProjectDetail, container;
 
 	beforeEach( () => {
 		actions = {
@@ -23,13 +23,14 @@ describe( "ProjectDetail Component", () => {
 			}
 		};
 		ProjectDetail = projectDetailFactory( dependencies );
+		container = document.createElement( "div" );
 	} );
 
 	function createComponent( props = {} ) {
 		if ( !props.params ) {
 			props.params = { name: "project", owner: "owner", branch: "branch" };
 		}
-		component = ReactUtils.renderIntoDocument( <ProjectDetail {...props} /> );
+		component = ReactDOM.render( <ProjectDetail {...props} />, container );
 	}
 
 	afterEach( () => {
@@ -72,9 +73,10 @@ describe( "ProjectDetail Component", () => {
 					owners: [],
 					versions: {}
 				} );
-				component.setProps( {
-					params: { name: "new-project", owner: "new-owner", branch: "branch" }
-				} );
+				ReactDOM.render(
+					<ProjectDetail params={ { name: "new-project", owner: "new-owner", branch: "branch" } } />,
+					container
+				);
 			} );
 
 			it( "should update state when receiving new props", () => {

--- a/client/spec/components/ProjectList.spec.jsx
+++ b/client/spec/components/ProjectList.spec.jsx
@@ -1,23 +1,28 @@
 import projectListFactory from "inject!ProjectList";
 
 describe( "ProjectList", () => {
-	let component, dependencies, selectStub;
+	let component, dependencies, selectStub, ProjectList;
 
 	beforeEach( () => {
 		dependencies = {};
-		const ProjectList = projectListFactory( dependencies );
+		ProjectList = projectListFactory( dependencies );
 		selectStub = sinon.stub();
-		component = ReactUtils.renderIntoDocument( <ProjectList projects={ [] } onSelectProject={ selectStub } /> );
 	} );
+
+	function render( props = {} ) {
+		component = ReactUtils.renderIntoDocument( <ProjectList projects={ [] } onSelectProject={ selectStub } {...props} /> );
+	}
 
 	afterEach( () => {
 		if ( component ) {
 			ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( component ).parentNode );
+			component = null;
 		}
 	} );
 
 	describe( "when handling props", () => {
 		it( "should have default props", () => {
+			render();
 			component.props.should.contain( {
 				title: "Projects"
 			} );
@@ -26,11 +31,12 @@ describe( "ProjectList", () => {
 
 	describe( "when rendering", () => {
 		it( "should render a title", () => {
+			render();
 			const title = ReactUtils.findRenderedDOMComponentWithClass( component, "box-title" );
-			title.getDOMNode().textContent.trim().should.equal( "Projects" );
+			title.textContent.trim().should.equal( "Projects" );
 		} );
 		it( "should render projects", () => {
-			component.setProps( {
+			render( {
 				projects: [
 					{ name: "project-one", owner: "owner-one", branch: "branch-one" },
 					{ name: "project-two", owner: "owner-two", branch: "branch-two" },
@@ -48,13 +54,13 @@ describe( "ProjectList", () => {
 			items[1].getAttribute( "href" ).should.equal( "/nonstop/project/project-two/owner-two/branch-two" );
 			items[2].getAttribute( "href" ).should.equal( "/nonstop/project/project-three/owner-three/branch-three" );
 
-			headings[0].getDOMNode().textContent.should.equal( "project-one" );
-			headings[1].getDOMNode().textContent.should.equal( "project-two" );
-			headings[2].getDOMNode().textContent.should.equal( "project-three" );
+			headings[0].textContent.should.equal( "project-one" );
+			headings[1].textContent.should.equal( "project-two" );
+			headings[2].textContent.should.equal( "project-three" );
 
-			details[0].getDOMNode().textContent.trim().should.equal( "owner-one/branch-one" );
-			details[1].getDOMNode().textContent.trim().should.equal( "owner-two/branch-two" );
-			details[2].getDOMNode().textContent.trim().should.equal( "owner-three/branch-three" );
+			details[0].textContent.trim().should.equal( "owner-one/branch-one" );
+			details[1].textContent.trim().should.equal( "owner-two/branch-two" );
+			details[2].textContent.trim().should.equal( "owner-three/branch-three" );
 		} );
 	} );
 
@@ -67,12 +73,12 @@ describe( "ProjectList", () => {
 				{ name: "project-two", owner: "owner", branch: "master" },
 				{ name: "project-three", owner: "owner", branch: "master" }
 			];
-			component.setProps( { projects } );
+			render( { projects } );
 		} );
 		it( "should trigger onSelectProject with the project name", () => {
 			let items = ReactUtils.scryRenderedDOMComponentsWithClass( component, "list-group-item" );
 
-			ReactUtils.Simulate.click( items[ 1 ].getDOMNode() );
+			ReactUtils.Simulate.click( items[ 1 ] );
 
 			selectStub.should.be.calledOnce.and.calledWith( projects[ 1 ] );
 		} );


### PR DESCRIPTION
Since `setProps` is deprecated (we only used it in specs anyway), I had to refactor our tests to remove it. The following guidelines emerged as I attempted the refactor (which describes some of the difference between the files)
1) If we are just testing props, render new component entirely with ReactUtils.renderIntoDocument any time you need to change the props.
2) If we are testing willReceiveProps or componentDidUpdate with props, then use React.render with a detached dom node.