### PR TITLE
HostConfigurator spec and split its dropdown into stateless component

### DIFF
--- a/client/js/components/HostConfigurator/HostConfigurator.jsx
+++ b/client/js/components/HostConfigurator/HostConfigurator.jsx
@@ -1,9 +1,8 @@
 import React from "react";
 import lux from "lux.js";
 import configurationStore from "stores/configurationStore";
+import OptionsDropdown from "OptionsDropdown";
 import "./HostConfigurator.less";
-import Dropdown from "react-bootstrap/lib/Dropdown";
-import MenuItem from "react-bootstrap/lib/MenuItem";
 
 function getState() {
 	return Object.assign( {}, configurationStore.getOptions(), { applyEnabled: configurationStore.getApplyEnabled() } );
@@ -18,108 +17,11 @@ export default React.createClass( {
 			this.setState( getState() );
 		}
 	},
-	getDefaultProps() {
-		return {};
-	},
 	getInitialState() {
 		return getState();
 	},
-	renderHostDropdown() {
-		const manyHosts = this.state.hosts.length > 1;
-		const selected = this.state.selectedHost;
-		return (
-			<div className="form-group">
-				<label className="hostConfiguration-dropdownLabel" htmlFor="hostDropdown">Host</label>
-				<Dropdown ref="hostDropdown" bsStyle="default" id="hostDropdown">
-					<Dropdown.Toggle disabled={ !manyHosts } noCaret={ !manyHosts }>
-						<i className="fa fa-book"></i> { selected && selected.name }
-					</Dropdown.Toggle>
-					<Dropdown.Menu>
-					{ this.state.hosts.map( host => {
-						return <MenuItem key={ host.name } onSelect={ this.selectHost.bind( this, host ) }>{ host.name }</MenuItem>;
-					} ) }
-					</Dropdown.Menu>
-				</Dropdown>
-			</div>
-		);
-	},
-	renderProjectDropdown() {
-		const manyProjects = this.state.projects.length > 1;
-		const selected = this.state.selectedProject;
-		return (
-			<div className="form-group">
-				<label className="hostConfiguration-dropdownLabel" htmlFor="projectDropdown">Project</label>
-				<Dropdown bsStyle="default" id="projectDropdown">
-					<Dropdown.Toggle disabled={ !manyProjects } noCaret={ !manyProjects }>
-						<i className="fa fa-book"></i> { selected }
-					</Dropdown.Toggle>
-					<Dropdown.Menu>
-					{ this.state.projects.map( project => {
-						return <MenuItem key={ project } onSelect={ this.selectProject.bind( this, project ) }>{ project }</MenuItem>;
-					} ) }
-					</Dropdown.Menu>
-				</Dropdown>
-			</div>
-		);
-	},
-	renderOwnerDropdown() {
-		const manyOwners = this.state.owners.length > 1;
-		const selected = this.state.selectedOwner;
-		return (
-			<div className="form-group">
-				<label className="hostConfiguration-dropdownLabel" htmlFor="ownerDropdown">Owner</label>
-				<Dropdown bsStyle="default" id="ownerDropdown">
-					<Dropdown.Toggle disabled={ !manyOwners } noCaret={ !manyOwners }>
-						<i className="fa fa-book"></i> { selected }
-					</Dropdown.Toggle>
-					<Dropdown.Menu>
-					{ this.state.owners.map( owner => {
-						return <MenuItem key={ owner } onSelect={ this.selectOwner.bind( this, owner ) }>{ owner }</MenuItem>;
-					} ) }
-					</Dropdown.Menu>
-				</Dropdown>
-			</div>
-		);
-	},
-	renderBranchDropdown() {
-		const manyBranches = this.state.branches.length > 1;
-		const selected = this.state.selectedBranch;
-		return (
-			<div className="form-group">
-				<label className="hostConfiguration-dropdownLabel" htmlFor="branchDropdown">Branch</label>
-				<Dropdown bsStyle="default" id="branchDropdown">
-					<Dropdown.Toggle disabled={ !manyBranches } noCaret={ !manyBranches }>
-						<i className="fa fa-book"></i> { selected }
-					</Dropdown.Toggle>
-					<Dropdown.Menu>
-					{ this.state.branches.map( branch => {
-						return <MenuItem key={ branch } onSelect={ this.selectBranch.bind( this, branch ) }>{ branch }</MenuItem>;
-					} ) }
-					</Dropdown.Menu>
-				</Dropdown>
-			</div>
-		);
-	},
-	renderVersionDropdown() {
-		const manyVersions = this.state.versions.length > 1;
-		const selected = this.state.selectedVersion;
-		return (
-			<div className="form-group">
-				<label className="hostConfiguration-dropdownLabel" htmlFor="versionDropdown">Version</label>
-				<Dropdown bsStyle="default" id="versionDropdown">
-					<Dropdown.Toggle disabled={ !manyVersions } noCaret={ !manyVersions }>
-						<i className="fa fa-book"></i> { selected }
-					</Dropdown.Toggle>
-					<Dropdown.Menu>
-					{ this.state.versions.map( version => {
-						return <MenuItem key={ version } onSelect={ this.selectVersion.bind( this, version ) }>{ version }</MenuItem>;
-					} ) }
-					</Dropdown.Menu>
-				</Dropdown>
-			</div>
-		);
-	},
 	render() {
+		const state = this.state;
 		return (
 			<div>
 				<section className="content-header">
@@ -136,11 +38,11 @@ export default React.createClass( {
 							<h3 className="box-title">Configuration Settings</h3>
 						</div>
 						<div className="box-body">
-						{ this.renderHostDropdown() }
-						{ this.renderProjectDropdown() }
-						{ this.renderOwnerDropdown() }
-						{ this.renderBranchDropdown() }
-						{ this.renderVersionDropdown() }
+							<OptionsDropdown name="host" selected={ state.selectedHost } options={ state.hosts } onSelect={ this.selectHost } />
+							<OptionsDropdown name="project" selected={ state.selectedProject } options={ state.projects } onSelect={ this.selectProject } />
+							<OptionsDropdown name="owner" selected={ state.selectedOwner } options={ state.owners } onSelect={ this.selectOwner } />
+							<OptionsDropdown name="branch" selected={ state.selectedBranch } options={ state.branches } onSelect={ this.selectBranch } />
+							<OptionsDropdown name="version" selected={ state.selectedVersion } options={ state.versions } onSelect={ this.selectVersion } />
 						</div>
 						<div className="box-footer">
 							<button disabled={ !this.state.applyEnabled } onClick={ this.applySettings.bind( this, null ) } type="submit" className="btn btn-primary">Apply Settings</button>

--- a/client/js/components/HostConfigurator/HostConfigurator.less
+++ b/client/js/components/HostConfigurator/HostConfigurator.less
@@ -1,5 +1,1 @@
 // HostConfigurator.less
-
-.hostConfiguration-dropdownLabel {
-	display:block;
-}

--- a/client/js/components/OptionsDropdown/OptionsDropdown.jsx
+++ b/client/js/components/OptionsDropdown/OptionsDropdown.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Dropdown from "react-bootstrap/lib/Dropdown";
+import MenuItem from "react-bootstrap/lib/MenuItem";
+import { capitalize } from "lodash";
+
+import "./OptionsDropdown.less";
+
+function getName( value ) {
+	return value && typeof value === "object" ? value.name : value;
+}
+
+const OptionsDropdown = ( { name, selected, options, onSelect } ) => {
+	const manyOptions = options.length > 1;
+	const id = `${ name }Dropdown`;
+
+	return (
+		<div className="form-group">
+			<label className="u-block" htmlFor={ id }>{ capitalize( name ) }</label>
+			<Dropdown bsStyle="default" id={ id }>
+				<Dropdown.Toggle disabled={ !manyOptions } noCaret={ !manyOptions }>
+					<i className="fa fa-book"></i> { getName( selected ) }
+				</Dropdown.Toggle>
+				<Dropdown.Menu>
+					{ options.map( option => {
+						return <MenuItem key={ getName( option ) } onSelect={ onSelect.bind( undefined, option ) }>{ getName( option ) }</MenuItem>;
+					} ) }
+				</Dropdown.Menu>
+			</Dropdown>
+		</div>
+	);
+};
+
+OptionsDropdown.propTypes = {
+	name: React.PropTypes.string,
+	onSelect: React.PropTypes.func,
+	options: React.PropTypes.array,
+	selected: React.PropTypes.oneOfType( [
+		React.PropTypes.object,
+		React.PropTypes.string
+	] )
+};
+
+export default OptionsDropdown;

--- a/client/js/components/OptionsDropdown/OptionsDropdown.less
+++ b/client/js/components/OptionsDropdown/OptionsDropdown.less
@@ -1,0 +1,1 @@
+// OptionsDropdown.less

--- a/client/spec/.eslintrc
+++ b/client/spec/.eslintrc
@@ -9,7 +9,8 @@
     "should": false,
     "sinon": false,
     "when": false,
-    "getMockReactComponent": false
+    "getMockReactComponent": false,
+    "wrapStatelessComponent": false
   },
 
   "env": {

--- a/client/spec/components/HostConfigurator.spec.jsx
+++ b/client/spec/components/HostConfigurator.spec.jsx
@@ -1,0 +1,153 @@
+import hostConfiguratorFactory from "inject!HostConfigurator";
+
+describe( "HostConfigurator", () => {
+	let actions, component, dependencies, optionsData;
+
+	beforeEach( () => {
+		actions = {
+			configureHost: sinon.stub(),
+			selectProject: sinon.stub(),
+			selectOwner: sinon.stub(),
+			selectBranch: sinon.stub(),
+			selectVersion: sinon.stub(),
+			selectHost: sinon.stub(),
+			applySettings: sinon.stub()
+		};
+
+		lux.customActionCreator( actions );
+
+		optionsData = {
+			selectedProject: "projectA",
+			selectedOwner: "ownerA",
+			selectedBranch: "branchA",
+			selectedVersion: "versionA",
+			selectedHost: { name: "hostA" },
+			projects: [ "projectA", "projectB" ],
+			owners: [ "ownerA", "ownerB" ],
+			branches: [ "branchA", "branchB" ],
+			versions: [ "versionA", "versionB" ],
+			hosts: [
+				{ name: "hostOne" }
+			]
+		};
+
+		dependencies = {
+			OptionsDropdown: getMockReactComponent( "OptionsDropdown" ),
+			"stores/configurationStore": {
+				getOptions: sinon.stub().returns( optionsData ),
+				getApplyEnabled: sinon.stub().returns( true )
+			}
+		};
+
+		const HostConfigurator = hostConfiguratorFactory( dependencies );
+
+		component = ReactUtils.renderIntoDocument( <HostConfigurator /> );
+	} );
+
+	afterEach( () => {
+		Object.keys( actions ).forEach( key => delete lux.actions[ key ] );
+
+		if ( component ) {
+			ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( component ).parentNode );
+		}
+	} );
+
+	describe( "when handling state", () => {
+		it( "should have initial state", () => {
+			component.state.should.eql( {
+				selectedProject: "projectA",
+				selectedOwner: "ownerA",
+				selectedBranch: "branchA",
+				selectedVersion: "versionA",
+				selectedHost: {
+					name: "hostA"
+				},
+				projects: [
+					"projectA",
+					"projectB"
+				],
+				owners: [
+					"ownerA",
+					"ownerB"
+				],
+				branches: [
+					"branchA",
+					"branchB"
+				],
+				versions: [
+					"versionA",
+					"versionB"
+				],
+				hosts: [
+					{ name: "hostOne" }
+				],
+				applyEnabled: true
+			} );
+		} );
+	} );
+
+	describe( "when rendering", () => {
+		let dropdowns;
+
+		beforeEach( () => {
+			dropdowns = _.indexBy( ReactUtils.scryRenderedComponentsWithType( component, dependencies.OptionsDropdown ), "props.name" );
+		} );
+
+		[ "host", "project", "owner", "branch", "version" ].forEach( field => {
+			describe( `Dropdown for ${ field }`, () => {
+				it( "should display the dropdown toggle", () => {
+					const dropdown = dropdowns[ field ];
+					const selected = optionsData[ `selected${ _.capitalize( field ) }` ];
+					const optionsField = `${ field }${ field !== "branch" ? "s" : "es" }`;
+					const options = optionsData[ optionsField ];
+					const onSelect = component[ `select${ _.capitalize( field ) }` ];
+
+					dropdown.props.should.eql( {
+						name: field,
+						selected,
+						options,
+						onSelect
+					} );
+				} );
+			} );
+		} );
+	} );
+
+	describe( "when handling store changes", () => {
+		[ "configuration", "project" ].forEach( ( namespace ) => {
+			it( `should update on changes to the ${ namespace } store`, () => {
+				dependencies[ "stores/configurationStore" ].getApplyEnabled.returns( false );
+				postal.channel( "lux.store" ).publish( `${ namespace }.changed` );
+
+				component.state.applyEnabled.should.be.false;
+			} );
+		} );
+	} );
+
+	describe( "applying settings", () => {
+		let applyButton;
+
+		beforeEach( () => {
+			const footer = ReactUtils.findRenderedDOMComponentWithClass( component, "box-footer" );
+			applyButton = footer.querySelector( "button" );
+		} );
+
+		it( "should be enabled when applyEnabled is true", () => {
+			applyButton.disabled.should.be.false;
+		} );
+
+		it( "should not be enabled when applyEnabled is false", () => {
+			component.state.applyEnabled = false;
+			component.forceUpdate();
+
+			applyButton.disabled.should.be.true;
+		} );
+
+		it( "should call the applySettings actions on click", () => {
+			ReactUtils.Simulate.click( applyButton );
+
+			// should specifically not pass settings as first arg
+			actions.applySettings.should.be.calledOnce.and.calledWith( null );
+		} );
+	} );
+} );

--- a/client/spec/components/OptionsDropdown.spec.jsx
+++ b/client/spec/components/OptionsDropdown.spec.jsx
@@ -1,0 +1,134 @@
+import optionsDropdownFactory from "inject!OptionsDropdown";
+
+describe( "OptionsDropdown", () => {
+	let component, components, dependencies, OptionsDropdown;
+
+	beforeEach( () => {
+		component = null;
+
+		let Dropdown = getMockReactComponent( "Dropdown" );
+		Dropdown.Toggle = getMockReactComponent( "Dropdown.Toggle" );
+		Dropdown.Menu = getMockReactComponent( "Dropdown.Menu" );
+
+		components = {
+			Dropdown: Dropdown,
+			MenuItem: getMockReactComponent( "MenuItem" )
+		};
+
+		dependencies = {
+			"react-bootstrap/lib/Dropdown": components.Dropdown,
+			"react-bootstrap/lib/MenuItem": components.MenuItem
+		};
+
+		OptionsDropdown = wrapStatelessComponent( optionsDropdownFactory( dependencies ) );
+	} );
+
+	function render( options ) {
+		component = ReactUtils.renderIntoDocument( <OptionsDropdown { ...options } /> );
+	}
+
+	afterEach( () => {
+		if ( component ) {
+			ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( component ).parentNode );
+		}
+	} );
+
+	describe( "when rendering", () => {
+		describe( "when values are strings", () => {
+			let props;
+
+			beforeEach( () => {
+				props = {
+					name: "test",
+					selected: "one",
+					options: [ "one", "two" ],
+					onSelect: sinon.stub()
+				};
+			} );
+
+			it( "should render a label", () => {
+				render( props );
+
+				const label = ReactUtils.findRenderedDOMComponentWithTag( component, "label" );
+				label.htmlFor.should.equal( "testDropdown" );
+				label.textContent.should.equal( "Test" );
+			} );
+
+			it( "should render the toggle", () => {
+				render( props );
+
+				const toggle = ReactUtils.findRenderedComponentWithType( component, components.Dropdown.Toggle );
+				ReactDOM.findDOMNode( toggle ).textContent.should.contain( "one" );
+			} );
+
+			it( "should set props on toggle correctly when there is only one option", () => {
+				props.options = [ "one" ];
+				render( props );
+
+				const toggle = ReactUtils.findRenderedComponentWithType( component, components.Dropdown.Toggle );
+				toggle.props.disabled.should.be.true;
+				toggle.props.noCaret.should.be.true;
+			} );
+
+			it( "should set props on toggle correctly when there is more than one option", () => {
+				render( props );
+
+				const toggle = ReactUtils.findRenderedComponentWithType( component, components.Dropdown.Toggle );
+				toggle.props.disabled.should.be.false;
+				toggle.props.noCaret.should.be.false;
+			} );
+
+			it( "should render the menu items", () => {
+				render( props );
+
+				const menuItems = ReactUtils.scryRenderedComponentsWithType( component, components.MenuItem );
+				menuItems.should.have.lengthOf( props.options.length );
+
+				_.each( menuItems, ( menuItem, index ) => {
+					const option = props.options[ index ];
+					const nodeText = ReactDOM.findDOMNode( menuItem ).textContent;
+					nodeText.should.contain( props.options[ index ] );
+
+					// ensure that onSelect function is properly bound to pass option
+					menuItem.props.onSelect();
+					props.onSelect.should.be.calledOnce.and.calledWith( option );
+					props.onSelect.reset();
+				} );
+			} );
+		} );
+
+		describe( "when values are objects", () => {
+			let props;
+
+			beforeEach( () => {
+				props = {
+					name: "test",
+					selected: { name: "one" },
+					options: [
+						{ name: "one" },
+						{ name: "two" }
+					],
+					onSelect: sinon.stub()
+				};
+
+				render( props );
+			} );
+
+			it( "should render the toggle", () => {
+				const toggle = ReactUtils.findRenderedComponentWithType( component, components.Dropdown.Toggle );
+				ReactDOM.findDOMNode( toggle ).textContent.should.contain( "one" );
+			} );
+
+			it( "should render the menu items", () => {
+				const menuItems = ReactUtils.scryRenderedComponentsWithType( component, components.MenuItem );
+				const menuItemsText = menuItems.map( item => ReactDOM.findDOMNode( item ).textContent );
+
+				menuItemsText.should.have.lengthOf( props.options.length );
+
+				_.each( menuItemsText, ( menuItem, index ) => {
+					menuItem.should.contain( props.options[ index ].name );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/spec/helpers/setup.js
+++ b/client/spec/helpers/setup.js
@@ -23,3 +23,12 @@ global.getMockReactComponent = function( name ) {
 		}
 	} );
 };
+
+// easier testing of stateless components with ReactUtils
+global.wrapStatelessComponent = function( Component ) {
+	return React.createClass( {
+		render() {
+			return <Component { ...this.props } />;
+		}
+	} );
+};


### PR DESCRIPTION
- split out dropdown used in HostConfigurator into a separate component called OptionsDropdown
- spec for HostConfigurator
- spec for OptionsDropdown. Added a helper in the setup file called `wrapStatelessComponent` to aid in testing stateless components, so that you can still use normal ReactUtils calls against a component tree,  based on some research into the topic. This would not be as necessary if the component only rendered simple DOM nodes that can be queried against, but in this case it renders mocked Bootstrap components and I need to be able to ensure that their props are accurate. Happy to talk this through and discuss further. Also interested at looking into [shallow rendering](https://facebook.github.io/react/docs/test-utils.html#shallow-rendering)