### PR TITLE
Set releaseOnly flag on HostConfigurator

### DIFF
--- a/client/js/components/HostConfigurator/HostConfigurator.jsx
+++ b/client/js/components/HostConfigurator/HostConfigurator.jsx
@@ -2,6 +2,9 @@ import React from "react";
 import lux from "lux.js";
 import configurationStore from "stores/configurationStore";
 import OptionsDropdown from "OptionsDropdown";
+import Switch from "react-bootstrap-switch";
+
+import "react-bootstrap-switch/src/less/bootstrap3/build.less";
 import "./HostConfigurator.less";
 
 function getState() {
@@ -10,7 +13,7 @@ function getState() {
 
 export default React.createClass( {
 	mixins: [ lux.reactMixin.actionCreator, lux.reactMixin.store ],
-	getActions: [ "configureHost", "selectProject", "selectOwner", "selectBranch", "selectVersion", "selectHost", "applySettings" ],
+	getActions: [ "applySettings", "configureHost", "selectProject", "selectOwner", "selectBranch", "selectVersion", "selectHost", "setReleaseOnly" ],
 	stores: {
 		listenTo: [ "configuration", "project" ],
 		onChange() {
@@ -43,6 +46,10 @@ export default React.createClass( {
 							<OptionsDropdown name="owner" selected={ state.selectedOwner } options={ state.owners } onSelect={ this.selectOwner } />
 							<OptionsDropdown name="branch" selected={ state.selectedBranch } options={ state.branches } onSelect={ this.selectBranch } />
 							<OptionsDropdown name="version" selected={ state.selectedVersion } options={ state.versions } onSelect={ this.selectVersion } />
+							<div className="form-group">
+								<label className="u-block">Release Only</label>
+								<Switch wrapperClass="hostConfigurator-releaseOnlySwitch" size="small" state={ state.releaseOnly } onChange={ this.setReleaseOnly } />
+							</div>
 						</div>
 						<div className="box-footer">
 							<button disabled={ !this.state.applyEnabled } onClick={ this.applySettings.bind( this, null ) } type="submit" className="btn btn-primary">Apply Settings</button>

--- a/client/js/components/HostConfigurator/HostConfigurator.less
+++ b/client/js/components/HostConfigurator/HostConfigurator.less
@@ -1,1 +1,4 @@
 // HostConfigurator.less
+.hostConfigurator-releaseOnly {
+	overflow: hidden;
+}

--- a/client/js/stores/configurationStore.js
+++ b/client/js/stores/configurationStore.js
@@ -1,10 +1,10 @@
 import lux from "lux.js";
-import { merge, set as _set, get as _get, each, all, cloneDeep } from "lodash";
+import { extend, set as _set, get as _get, each, all, cloneDeep } from "lodash";
 import projectStore from "./projectStore";
 
 function updateSelections( store, updatedSelections ) {
 	const { selections: currentSelections, tree } = store.getState();
-	const mergedSelections = merge( currentSelections, updatedSelections );
+	const mergedSelections = extend( currentSelections, updatedSelections );
 
 	store.setState( {
 		selections: getSelections( mergedSelections, tree )

--- a/client/js/stores/configurationStore.js
+++ b/client/js/stores/configurationStore.js
@@ -23,7 +23,8 @@ function getSelections( current, tree ) {
 		owner,
 		branch,
 		version,
-		host
+		host,
+		releaseOnly: current.releaseOnly
 	};
 }
 
@@ -36,7 +37,8 @@ export default new lux.Store( {
 			project: undefined,
 			owner: undefined,
 			branch: undefined,
-			version: undefined
+			version: undefined,
+			releaseOnly: false
 		},
 		updateInProgress: false
 	},
@@ -82,6 +84,12 @@ export default new lux.Store( {
 				host: host
 			} );
 		},
+		setReleaseOnly( value ) {
+			const state = this.getState();
+			state.selections.releaseOnly = value;
+
+			this.setState( state );
+		},
 		applySettings() {
 			this.setState( { updateInProgress: true } );
 		},
@@ -105,6 +113,8 @@ export default new lux.Store( {
 		const selectedVersion = state.selections.version;
 		const hosts = projectStore.getHosts();
 		const selectedHost = state.selections.host;
+		const releaseOnly = state.selections.releaseOnly;
+
 		return {
 			projects,
 			owners,
@@ -115,7 +125,8 @@ export default new lux.Store( {
 			selectedOwner,
 			selectedBranch,
 			selectedVersion,
-			selectedHost
+			selectedHost,
+			releaseOnly
 		};
 	},
 	getChanges() {
@@ -133,6 +144,10 @@ export default new lux.Store( {
 	},
 	getApplyEnabled() {
 		const state = this.getState();
-		return all( state.selections ) && !state.updateInProgress;
+		const allTrue = all( state.selections, ( value, key ) => {
+			return value || key === "releaseOnly";
+		} );
+
+		return allTrue && !state.updateInProgress;
 	}
 } );

--- a/client/js/stores/projectStore.js
+++ b/client/js/stores/projectStore.js
@@ -2,7 +2,7 @@ import lux from "lux.js";
 import { map, reduce, get as _get, set as _set, find, cloneDeep, groupBy } from "lodash";
 
 function getHostDetails( host ) {
-	const { project, branch, owner } = host.package;
+	const { project, branch, owner, releaseOnly } = host.package;
 	const { name: hostName, ip } = host.serviceHost.host;
 
 	return {
@@ -11,7 +11,8 @@ function getHostDetails( host ) {
 		branch,
 		owner,
 		hostName,
-		ip
+		ip,
+		releaseOnly
 	};
 }
 

--- a/client/spec/components/HostConfigurator.spec.jsx
+++ b/client/spec/components/HostConfigurator.spec.jsx
@@ -11,7 +11,8 @@ describe( "HostConfigurator", () => {
 			selectBranch: sinon.stub(),
 			selectVersion: sinon.stub(),
 			selectHost: sinon.stub(),
-			applySettings: sinon.stub()
+			applySettings: sinon.stub(),
+			setReleaseOnly: sinon.stub()
 		};
 
 		lux.customActionCreator( actions );
@@ -22,6 +23,7 @@ describe( "HostConfigurator", () => {
 			selectedBranch: "branchA",
 			selectedVersion: "versionA",
 			selectedHost: { name: "hostA" },
+			releaseOnly: false,
 			projects: [ "projectA", "projectB" ],
 			owners: [ "ownerA", "ownerB" ],
 			branches: [ "branchA", "branchB" ],
@@ -36,7 +38,8 @@ describe( "HostConfigurator", () => {
 			"stores/configurationStore": {
 				getOptions: sinon.stub().returns( optionsData ),
 				getApplyEnabled: sinon.stub().returns( true )
-			}
+			},
+			"react-bootstrap-switch": getMockReactComponent( "Switch" )
 		};
 
 		const HostConfigurator = hostConfiguratorFactory( dependencies );
@@ -62,6 +65,7 @@ describe( "HostConfigurator", () => {
 				selectedHost: {
 					name: "hostA"
 				},
+				releaseOnly: false,
 				projects: [
 					"projectA",
 					"projectB"
@@ -137,8 +141,9 @@ describe( "HostConfigurator", () => {
 		} );
 
 		it( "should not be enabled when applyEnabled is false", () => {
-			component.state.applyEnabled = false;
-			component.forceUpdate();
+			component.setState( {
+				applyEnabled: false
+			} );
 
 			applyButton.disabled.should.be.true;
 		} );
@@ -148,6 +153,30 @@ describe( "HostConfigurator", () => {
 
 			// should specifically not pass settings as first arg
 			actions.applySettings.should.be.calledOnce.and.calledWith( null );
+		} );
+	} );
+
+	describe( "setting releaseOnly flag", () => {
+		let releaseOnlySwitch;
+
+		beforeEach( () => {
+			 releaseOnlySwitch = ReactUtils.findRenderedComponentWithType( component, dependencies[ "react-bootstrap-switch" ] );
+		} );
+
+		it( "should call the setReleaseOnly action with the appropriate value", () => {
+			releaseOnlySwitch.props.onChange( true );
+
+			actions.setReleaseOnly.should.be.calledOnce.and.calledWith( true );
+		} );
+
+		it( "should set the checkbox value based on the releaseOnly state", () => {
+			releaseOnlySwitch.props.state.should.be.false;
+
+			component.setState( {
+				releaseOnly: true
+			} );
+
+			releaseOnlySwitch.props.state.should.be.true;
 		} );
 	} );
 } );

--- a/client/spec/data/hostsParsed.js
+++ b/client/spec/data/hostsParsed.js
@@ -6,7 +6,8 @@ module.exports = {
 			ip: "10.0.0.6",
 			name: "core-blu",
 			owner: "BanditSoftware",
-			project: "nonstop-index-ui"
+			project: "nonstop-index-ui",
+			releaseOnly: false
 		},
 		{
 			branch: "master",
@@ -14,7 +15,8 @@ module.exports = {
 			ip: "10.0.0.6",
 			name: "littlebrudder",
 			owner: "arobson",
-			project: "nonstop-index-ui"
+			project: "nonstop-index-ui",
+			releaseOnly: true
 		}
 	]
 };

--- a/client/spec/data/hostsResponse.js
+++ b/client/spec/data/hostsResponse.js
@@ -21,7 +21,8 @@ module.exports = {
 				osVersion: "any",
 				osName: "any",
 				architecture: "x64",
-				platform: "linux"
+				platform: "linux",
+				releaseOnly: false
 			},
 			index: {
 				host: "10.0.0.4",
@@ -156,7 +157,8 @@ module.exports = {
 				osVersion: "any",
 				osName: "any",
 				architecture: "x64",
-				platform: "linux"
+				platform: "linux",
+				releaseOnly: true
 			},
 			index: {
 				host: "10.0.0.4",

--- a/client/spec/data/hostsWithStatus.js
+++ b/client/spec/data/hostsWithStatus.js
@@ -8,6 +8,7 @@ module.exports = [
 		ip: "10.0.0.6",
 		slug: "f9638e2f",
 		version: "0.2.1-34",
+		releaseOnly: false,
 		status: {
 			hostUptime: "21 hours 41 minutes 21 seconds",
 			serviceUptime: "1 hours 6 minutes 24 seconds",
@@ -20,6 +21,7 @@ module.exports = [
 		branch: "master",
 		owner: "arobson",
 		hostName: "littelbrudder.hack.leankitdev.com",
-		ip: "10.0.0.6"
+		ip: "10.0.0.6",
+		releaseOnly: true
 	}
 ];

--- a/client/spec/data/packagesParsedForConfiguration.js
+++ b/client/spec/data/packagesParsedForConfiguration.js
@@ -95,12 +95,14 @@ module.exports = {
 			ip: "10.0.0.6",
 			name: "core-blu",
 			owner: "BanditSoftware",
-			project: "nonstop-index-ui"
+			project: "nonstop-index-ui",
+			releaseOnly: false
 		},
 		project: "core-blu",
 		owner: "BanditSoftware",
 		branch: "master",
-		version: "0.1.5"
+		version: "0.1.5",
+		releaseOnly: false
 	},
 	updateInProgress: false
 };

--- a/client/spec/stores/configurationStore.spec.js
+++ b/client/spec/stores/configurationStore.spec.js
@@ -55,7 +55,9 @@ describe( "configuration store", () => {
 			configurationStore.getState().should.eql( {
 				tree: {},
 				packages: [],
-				selections: {},
+				selections: {
+					releaseOnly: false
+				},
 				updateInProgress: false
 			} );
 		} );
@@ -83,7 +85,8 @@ describe( "configuration store", () => {
 					project: "projectB",
 					owner: "ownerB",
 					branch: "branchB",
-					version: "versionB"
+					version: "versionB",
+					releaseOnly: false
 				};
 			} );
 
@@ -95,7 +98,8 @@ describe( "configuration store", () => {
 					owner: "ownerA",
 					branch: "branchA",
 					version: "versionA",
-					host: defaultHost
+					host: defaultHost,
+					releaseOnly: false
 				} );
 			} );
 
@@ -108,7 +112,8 @@ describe( "configuration store", () => {
 					owner: "ownerB",
 					branch: "branchA",
 					version: "versionB",
-					host: defaultHost
+					host: defaultHost,
+					releaseOnly: false
 				} );
 			} );
 
@@ -125,7 +130,8 @@ describe( "configuration store", () => {
 					owner: "ownerA",
 					branch: "branchB",
 					version: "versionA",
-					host: defaultHost
+					host: defaultHost,
+					releaseOnly: false
 				} );
 			} );
 
@@ -143,7 +149,8 @@ describe( "configuration store", () => {
 					owner: "ownerA",
 					branch: "branchA",
 					version: "versionB",
-					host: defaultHost
+					host: defaultHost,
+					releaseOnly: false
 				} );
 			} );
 
@@ -157,8 +164,17 @@ describe( "configuration store", () => {
 					version: "versionB",
 					host: {
 						name: "five"
-					}
+					},
+					releaseOnly: false
 				} );
+			} );
+
+			it( "should update releaseOnly from setReleaseOnly action", () => {
+				lux.publishAction( "setReleaseOnly", true );
+				configurationStore.getState().selections.releaseOnly.should.be.true;
+
+				lux.publishAction( "setReleaseOnly", false );
+				configurationStore.getState().selections.releaseOnly.should.be.false;
 			} );
 		} );
 
@@ -217,7 +233,8 @@ describe( "configuration store", () => {
 				owners: [ "ownerA", "ownerB" ],
 				branches: [ "branchA", "branchB" ],
 				versions: [ "versionA", "versionB" ],
-				hosts: hostsParsed.hosts
+				hosts: hostsParsed.hosts,
+				releaseOnly: false
 			} );
 		} );
 
@@ -225,6 +242,7 @@ describe( "configuration store", () => {
 			configurationStore.getChanges().should.eql( {
 				name: "hostA",
 				data: [
+					{ op: "change", field: "releaseOnly", value: false },
 					{ op: "change", field: "project", value: "projectA" },
 					{ op: "change", field: "owner", value: "ownerA" },
 					{ op: "change", field: "branch", value: "branchA" },
@@ -245,7 +263,7 @@ describe( "configuration store", () => {
 				} );
 			} );
 
-			it( "should return false when all selections are not set", () => {
+			it( "should return false when all selections other than releaseOnly are not set", () => {
 				selections.project = null;
 				configurationStore.getState().updateInProgress = false;
 
@@ -257,7 +275,7 @@ describe( "configuration store", () => {
 				configurationStore.getApplyEnabled().should.be.false;
 			} );
 
-			it( "should return true when all selections are set and updateInProgress in true", () => {
+			it( "should return true when all selections are set and updateInProgress is true", () => {
 				configurationStore.getApplyEnabled().should.be.true;
 			} );
 		} );

--- a/client/spec/stores/projectStore.spec.js
+++ b/client/spec/stores/projectStore.spec.js
@@ -214,7 +214,8 @@ describe( "project store", () => {
 						ip: "10.0.0.6",
 						name: "core-blu",
 						owner: "BanditSoftware",
-						project: "nonstop-index-ui"
+						project: "nonstop-index-ui",
+						releaseOnly: false
 					},
 					pkg: {
 						project: "Heyo"
@@ -309,8 +310,24 @@ describe( "project store", () => {
 
 				hosts.length.should.equal( 2 );
 				hosts.should.eql( [
-					{ name: "core-blu", project: "nonstop-index-ui", branch: "master", owner: "BanditSoftware", hostName: "lkapp.cloudapp.net", ip: "10.0.0.6" },
-					{ name: "littlebrudder", project: "nonstop-index-ui", branch: "master", owner: "arobson", hostName: "littelbrudder.hack.leankitdev.com", ip: "10.0.0.6" }
+					{
+						name: "core-blu",
+						project: "nonstop-index-ui",
+						branch: "master",
+						owner: "BanditSoftware",
+						hostName: "lkapp.cloudapp.net",
+						ip: "10.0.0.6",
+						releaseOnly: false
+					},
+					{
+						name: "littlebrudder",
+						project: "nonstop-index-ui",
+						branch: "master",
+						owner: "arobson",
+						hostName: "littelbrudder.hack.leankitdev.com",
+						ip: "10.0.0.6",
+						releaseOnly: true
+					}
 				] );
 			} );
 		} );

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "monologue.js": "^0.3.3",
     "postal": "1.x",
     "react": "^0.14.3",
+    "react-bootstrap-switch": "^3.4.0",
     "react-router": "^0.13.3",
     "redis": "^0.12.1",
     "request": "2.60.0",


### PR DESCRIPTION
This PR covers setting the release only flag for a host on the host configurator.  

Possible follow-up work:
- confirmation for applying settings on host configurator
- default in project/branch, etc. when selecting a host based on what is currently running on the host

Note: we believe we are making the correct API call when setting this flag. @arobson indicated that the flag was not set on a host that we called it on and was going to look into why.